### PR TITLE
Fix errors in _variables.scss

### DIFF
--- a/lib/scss/_variables.scss
+++ b/lib/scss/_variables.scss
@@ -1,3 +1,5 @@
+@import "functions";
+
 // Variables
 //
 // Variables should follow the `$component-state-property-size` formula for
@@ -165,7 +167,7 @@ $body-color:                $gray-900 !default;
 //
 // Style anchor elements.
 
-$link-color:                theme-color("primary") !default;
+$link-color:                map-get($theme-colors, "primary") !default;
 $link-decoration:           none !default;
 $link-hover-color:          darken($link-color, 15%) !default;
 $link-hover-decoration:     underline !default;
@@ -234,7 +236,7 @@ $box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
 $box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
 
 $component-active-color:      $white !default;
-$component-active-bg:         theme-color("primary") !default;
+$component-active-bg:         map-get($theme-colors, "primary") !default;
 
 $caret-width:                 .3em !default;
 
@@ -483,7 +485,7 @@ $custom-control-label-disabled-color:           $gray-600 !default;
 
 $custom-control-indicator-checked-color:        $component-active-color !default;
 $custom-control-indicator-checked-bg:           $component-active-bg !default;
-$custom-control-indicator-checked-disabled-bg:  rgba(theme-color("primary"), .5) !default;
+$custom-control-indicator-checked-disabled-bg:  rgba(map-get($theme-colors, "primary"), .5) !default;
 $custom-control-indicator-checked-box-shadow:   none !default;
 
 $custom-control-indicator-focus-box-shadow:     0 0 0 1px $body-bg, $input-btn-focus-box-shadow !default;
@@ -571,8 +573,8 @@ $custom-file-text: (
 // Form validation
 $form-feedback-margin-top:          $form-text-margin-top !default;
 $form-feedback-font-size:           $small-font-size !default;
-$form-feedback-valid-color:         theme-color("success") !default;
-$form-feedback-invalid-color:       theme-color("danger") !default;
+$form-feedback-valid-color:         map-get($theme-colors, "success") !default;
+$form-feedback-invalid-color:       map-get($theme-colors, "danger") !default;
 
 
 // Dropdowns
@@ -841,7 +843,7 @@ $progress-bg:                       $gray-200 !default;
 $progress-border-radius:            $border-radius !default;
 $progress-box-shadow:               inset 0 .1rem .1rem rgba($black, .1) !default;
 $progress-bar-color:                $white !default;
-$progress-bar-bg:                   theme-color("primary") !default;
+$progress-bar-bg:                   map-get($theme-colors, "primary") !default;
 $progress-bar-animation-timing:     1s linear infinite !default;
 $progress-bar-transition:           width .6s ease !default;
 


### PR DESCRIPTION
- Add missing import for _assert-ascending mixin.
- Use map-get function to get values from the theme-colors map.

These were the minimal fixes I needed to add to get the example in the sass_builder repo working with the latest version of this package.