### PR TITLE
v4.6.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,28 @@
+name: Dart CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - name: Dart version
+        run: |
+          dart --version
+          uname -a
+      - name: Install dependencies
+        run: dart pub get
+      - name: dart format
+        run: dart format -o none --set-exit-if-changed .
+      - name: dart analyze
+        run: dart analyze --fatal-infos --fatal-warnings .
+      - name: dart pub publish --dry-run
+        run: dart pub publish --dry-run
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.6.0
+
+- Upgrade SDK to support null safety and Dart 3.
+  - sdk: '>=2.18.0 <3.0.0'
+  - The version has been upgraded to `4.6.0` due the SDK constraint upgrade. 
+- Added GitHUB action (Dart CI) with basic checks.
+- sass_builder: ^2.2.1
+- lints: ^2.0.1
+
 ## 4.5.0
 
 - upgrade to v4.5.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,11 +2,16 @@ name: bootstrap_sass_example # change this line to have your library name
 description: An absolute bare-bones web app.
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  bootstrap_sass: ^4.5.0
+  bootstrap_sass: ^4.6.0
+
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_web_compilers: ^2.0.0
-  sass_builder: ^2.0.0
+  build_runner: any
+  build_web_compilers: any
+  sass_builder: ^2.2.1
+
+dependency_overrides:
+  bootstrap_sass:
+    path: ../

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -1,3 +1,1 @@
-
-void main() {
-}
+void main() {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,14 @@
 name: bootstrap_sass
-version: 4.5.0
-description: Sass source files to create bootstrap themes
-author: Luis Vargas <luisvargastijerino@gmail.com>
+version: 4.6.0
+description: Sass source files to create Bootstrap themes for Dart Web.
 homepage: https://github.com/luisvt/bootstrap_sass
+
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
+
 dev_dependencies:
-  sass_builder: ^2.1.2
+  sass_builder: ^2.2.1
   build_runner: any
   build_test: any
   build_web_compilers: any
+  lints: ^2.0.1


### PR DESCRIPTION
- Upgrade SDK to support null safety and Dart 3.
  - sdk: '>=2.18.0 <3.0.0'
  - The version has been upgraded to `4.6.0` due the SDK constraint upgrade.
- Added GitHUB action (Dart CI) with basic checks.
- sass_builder: ^2.2.1
- lints: ^2.0.1